### PR TITLE
docker/docker-server: added db name

### DIFF
--- a/docker/docker-server/.env-local-template
+++ b/docker/docker-server/.env-local-template
@@ -1,6 +1,7 @@
 
 # MySQL 
 
+MYSQL_DATABASE=mlflow
 MYSQL_ROOT_PASSWORD=efcodd
 HOST_MYSQL_PORT=5306
 HOST_MYSQL_DATA_DIR=/opt/mlflow_docker/mysql

--- a/docker/docker-server/docker-compose.yaml
+++ b/docker/docker-server/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile-mysql
     environment:
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
     ports:
      - "${HOST_MYSQL_PORT}:3306"
@@ -24,6 +25,7 @@ services:
     depends_on:
       - db
     environment:
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
       - MLFLOW_ARTIFACT_URI=${MLFLOW_ARTIFACT_URI}
     ports:

--- a/docker/docker-server/src/mysql/create_db.sql
+++ b/docker/docker-server/src/mysql/create_db.sql
@@ -1,1 +1,0 @@
-create database mlflow;

--- a/docker/docker-server/src/run_server.sh
+++ b/docker/docker-server/src/run_server.sh
@@ -1,6 +1,6 @@
 
 run() {
-  STORE_URI=mysql://root:${MYSQL_ROOT_PASSWORD}@db/mlflow
+  STORE_URI=mysql://root:${MYSQL_ROOT_PASSWORD}@db/${MYSQL_DATABASE}
   echo "STORE_URI=$STORE_URI"
   echo "MLFLOW_ARTIFACT_URI=$MLFLOW_ARTIFACT_URI"
   mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri $STORE_URI --default-artifact-root $MLFLOW_ARTIFACT_URI 


### PR DESCRIPTION
docker example doesn't work, there is an error in mlflow_server logs:
`(MySQLdb.OperationalError) (1049, "Unknown database 'mlflow'")`
Environment variable $MYSQL_DATABASE fixes it